### PR TITLE
Update module path to new location

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,7 @@ automerge-go provides the ability to interact with [automerge] documents.
 It is a featureful wrapper around [automerge-rs] that uses cgo to avoid reimplementing
 the core engine from scratch.
 
-## Installation
-
-```
-go get github.com/ConradIrwin/automerge-go
-```
-
-## Usage
-
-See the Go documentation at https://pkg.go.dev/github.com/ConradIrwin/automerge-go.
-
-## Limitations
-
-automerge-go comes with precompiled libraries for linux and mac on amd64 (x86_64) and
-arm64.
-
-Supporting further architectures will require cross compiling automerge-rs and adding
-them to the deps/ directory.
+For package documentation, see the Go documentation at https://pkg.go.dev/github.com/automerge/automerge-go.
 
 [automerge]: https://automerge.org
 [automerge-rs]: https://github.com/automerge/automerge-rs

--- a/cgo_test.go
+++ b/cgo_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ConradIrwin/automerge-go"
+	"github.com/automerge/automerge-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,7 @@ package automerge_test
 import (
 	"fmt"
 
-	"github.com/ConradIrwin/automerge-go"
+	"github.com/automerge/automerge-go"
 )
 
 func ExampleAs() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ConradIrwin/automerge-go
+module github.com/automerge/automerge-go
 
 go 1.19
 

--- a/path_test.go
+++ b/path_test.go
@@ -3,7 +3,7 @@ package automerge_test
 import (
 	"testing"
 
-	"github.com/ConradIrwin/automerge-go"
+	"github.com/automerge/automerge-go"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
Although we moved the repo, it was still known by its old name.
