### PR TITLE
Revamp API

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -26,40 +26,6 @@ func ExampleAs() {
 	fmt.Println(s.IsValid == true)
 }
 
-func ExampleList_Iter() {
-	doc := automerge.New()
-	list := doc.Path("list").List()
-
-	iter := list.Iter()
-	for {
-		i, v, valid := iter.Next()
-		if !valid {
-			break
-		}
-		fmt.Println(i, v)
-	}
-	if iter.Error() != nil {
-		panic(iter.Error())
-	}
-}
-
-func ExampleMap_Iter() {
-	doc := automerge.New()
-	m := doc.Path("map").Map()
-
-	iter := m.Iter()
-	for {
-		k, v, valid := iter.Next()
-		if !valid {
-			break
-		}
-		fmt.Println(k, v)
-	}
-	if iter.Error() != nil {
-		panic(iter.Error())
-	}
-}
-
 func ExampleSyncState() {
 	doc := automerge.New()
 	syncState := automerge.NewSyncState(doc)
@@ -72,10 +38,7 @@ loop:
 	// generate an initial message, and then do so again
 	// after receiving updates from the peer or making local changes
 	for {
-		msg, valid, err := syncState.GenerateMessage()
-		if err != nil {
-			panic(err)
-		}
+		msg, valid := syncState.GenerateMessage()
 		if valid {
 			send <- msg
 		}


### PR DESCRIPTION
This commit significantly changes the API for interacting with the
Doc to reduce the overall surface area, and tidy up some unnecessary
error returns.

A short summary of changes:

* type Changes => []*Change
* type ChangeHashes => []ChangeHash
* type ActorID => string
* type MapIter => Map.Values()
* type ListIter => List.Values()

Many of the read-only methods provided by automerge-rs return an
AMresult that is guaranteed to be AM_RESULT_SUCCESS. A number of APIs on
the document have had their error handler removed.

Methods that take an optional list of arguments have been updated to
take var-args instead. That is significantly nicer to use in the common
case of 0 or 1 arguments, and still possible if you are passing many.

The Change type was added so that you can now use automerge-go to
explore the history graph of an automerge document. Operations are
not yet exposed.
