### PR TITLE
v0.2

### DIFF
--- a/automerge.go
+++ b/automerge.go
@@ -69,6 +69,23 @@ assume the path is of the type you say it is:
 When you do this, any errors caused by traversing the path will be returned from
 methods called on the returned objects.
 
+# Controling formatting of structs
+
+By default automerge will convert your struct to a map. For each public field in the
+struct (the name starts with an uppercase letter) automerge will add an entry to the
+map with the name of the field and the fields value converted to an automerge value
+recursively.
+
+You can control this behaviour using struct tags:
+
+	struct Example {
+		Renamed bool `automerge:"newname"`
+		Private bool `automerge:"-"`
+	}
+
+If the tag is present and equal to "-" the field will be ignored by automerge,
+otherwise the fields name will be set to the value of the tag.
+
 # Syncing and concurrency
 
 You can access methods on [*Doc] from multiple goroutines and access is mediated

--- a/automerge_test.go
+++ b/automerge_test.go
@@ -215,7 +215,7 @@ func TestMap(t *testing.T) {
 
 	require.Equal(t, "&automerge.Map{\"string\": \"hello\"}", n.GoString())
 
-	require.NoError(t, m.Del("map"))
+	require.NoError(t, m.Delete("map"))
 	v, err := m.Get("map")
 	require.NoError(t, err)
 	require.True(t, v.IsVoid())

--- a/automerge_test.go
+++ b/automerge_test.go
@@ -680,7 +680,7 @@ func TestSyncState(t *testing.T) {
 
 	resync := func() {
 		var valid1, valid2 bool
-		var m []byte
+		var m *automerge.SyncMessage
 		var err error
 
 		for {
@@ -689,15 +689,16 @@ func TestSyncState(t *testing.T) {
 			if !valid1 {
 				break
 			}
-			require.NoError(t, sState.ReceiveMessage(m))
+			_, err = sState.ReceiveMessage(m.Bytes())
+			require.NoError(t, err)
 
 			m, valid2 = sState.GenerateMessage()
 			require.NoError(t, err)
 			if !valid2 {
 				break
 			}
-
-			require.NoError(t, cState.ReceiveMessage(m))
+			_, err = cState.ReceiveMessage(m.Bytes())
+			require.NoError(t, err)
 		}
 	}
 
@@ -721,10 +722,8 @@ func TestSyncState(t *testing.T) {
 	require.Equal(t, cV, sV)
 	require.Equal(t, map[string]int{"s": 15, "c": 15}, cV)
 
-	cBytes, err := cState.Save()
-	require.NoError(t, err)
-	sBytes, err := sState.Save()
-	require.NoError(t, err)
+	cBytes := cState.Save()
+	sBytes := sState.Save()
 	cState, err = automerge.LoadSyncState(cDoc, cBytes)
 	require.NoError(t, err)
 	sState, err = automerge.LoadSyncState(sDoc, sBytes)

--- a/example_test.go
+++ b/example_test.go
@@ -24,7 +24,7 @@ func ExampleAs() {
 	fmt.Println("foo-bar:", v)
 
 	type S struct {
-		IsValid bool `json:"isValid"`
+		IsValid bool `automerge:"isValid"`
 	}
 	s, err := automerge.As[*S](doc.Root())
 	if err != nil {

--- a/example_test.go
+++ b/example_test.go
@@ -52,7 +52,7 @@ loop:
 	for {
 		msg, valid := syncState.GenerateMessage()
 		if valid {
-			send <- msg
+			send <- msg.Bytes()
 		}
 
 		select {
@@ -61,7 +61,7 @@ loop:
 				break loop
 			}
 
-			err := syncState.ReceiveMessage(msg)
+			_, err := syncState.ReceiveMessage(msg)
 			if err != nil {
 				panic(err)
 			}

--- a/item.go
+++ b/item.go
@@ -251,10 +251,10 @@ func (i *item) syncState() *SyncState {
 	return ss
 }
 
-func (i *item) syncMessage() *syncMessage {
+func (i *item) syncMessage() *SyncMessage {
 	defer runtime.KeepAlive(i)
 
-	ss := &syncMessage{item: i}
+	ss := &SyncMessage{item: i}
 	if !C.AMitemToSyncMessage(i.cItem, &ss.cSyncMessage) {
 		if i.Kind() == KindVoid {
 			return nil

--- a/map.go
+++ b/map.go
@@ -87,7 +87,7 @@ func (m *Map) Len() int {
 	return int(C.AMobjSize(cDoc, cObj, nil))
 }
 
-// Del deletes a key and its corresponding value from the map
+// Delete deletes a key and its corresponding value from the map
 func (m *Map) Delete(key string) error {
 	if m.doc == nil {
 		return fmt.Errorf("automerge.Map: tried to write to detached map")

--- a/map.go
+++ b/map.go
@@ -88,7 +88,7 @@ func (m *Map) Len() int {
 }
 
 // Del deletes a key and its corresponding value from the map
-func (m *Map) Del(key string) error {
+func (m *Map) Delete(key string) error {
 	if m.doc == nil {
 		return fmt.Errorf("automerge.Map: tried to write to detached map")
 	}

--- a/normalize.go
+++ b/normalize.go
@@ -1,9 +1,9 @@
 package automerge
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 )
 
@@ -19,50 +19,115 @@ func normalize(value any) (any, error) {
 		return nil, nil
 	}
 
-	switch value.(type) {
-	case bool, string, []byte, int64, uint64, float64,
-		time.Time, map[string]any, []any,
-		*Counter, *Text, *Map, *List, *Value:
-		return value, nil
-	}
-
 	rv := reflect.ValueOf(value)
-
-	switch {
-	case rv.CanFloat():
-		return rv.Float(), nil
-	case rv.CanInt():
-		return float64(rv.Int()), nil
-	case rv.CanUint():
-		return rv.Uint(), nil
-	case rv.CanConvert(boolType):
+	switch rv.Kind() {
+	case reflect.Bool:
 		return rv.Bool(), nil
-	case rv.CanConvert(stringType):
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
+		return float64(rv.Int()), nil
+	case reflect.Int64:
+		return rv.Int(), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32:
+		return float64(rv.Uint()), nil
+	case reflect.Uint64:
+		return rv.Uint(), nil
+	case reflect.Float32, reflect.Float64:
+		return rv.Float(), nil
+	case reflect.String:
 		return rv.String(), nil
-	}
+	case reflect.Interface:
+		return normalize(rv.Elem().Interface())
 
-	// TODO: this is a quite expensive approach...
-	bytes, err := json.Marshal(value)
-	if err != nil {
-		return nil, fmt.Errorf("automerge: unsupported value: %#v", value)
-	}
-
-	if bytes[0] == '[' {
-		value = []any{}
-		if err := json.Unmarshal(bytes, &value); err != nil {
-			return nil, fmt.Errorf("automerge: unsupported value: %#v", value)
+	case reflect.Pointer:
+		switch reflect.TypeOf(value) {
+		case reflect.TypeOf(&Map{}):
+			return value.(*Map), nil
+		case reflect.TypeOf(&Text{}):
+			return value.(*Text), nil
+		case reflect.TypeOf(&List{}):
+			return value.(*List), nil
+		case reflect.TypeOf(&Counter{}):
+			return value.(*Counter), nil
 		}
-		return value, nil
-	}
-	if bytes[0] == '{' {
-		value = map[string]any{}
-		if err := json.Unmarshal(bytes, &value); err != nil {
-			return nil, fmt.Errorf("automerge: unsupported value: %#v", value)
-		}
-		return value, nil
-	}
+		return normalize(rv.Elem().Interface())
 
-	return nil, fmt.Errorf("automerge: unsupported value: %#v", value)
+	case reflect.Slice, reflect.Array:
+		if rv.Type().Elem().Kind() == reflect.Uint8 {
+			ret := []byte{}
+			for i := 0; i < rv.Len(); i++ {
+				ret = append(ret, byte(rv.Index(i).Uint()))
+			}
+			return ret, nil
+		}
+
+		ret := []any{}
+
+		for i := 0; i < rv.Len(); i++ {
+			v, err := normalize(rv.Index(i).Interface())
+			if err != nil {
+				return nil, err
+			}
+			ret = append(ret, v)
+		}
+		return ret, nil
+
+	case reflect.Map:
+		ret := map[string]any{}
+
+		if rv.Type().Key().Kind() != reflect.String {
+			return nil, fmt.Errorf("automerge: unsupported map, must have string keys")
+		}
+
+		for _, k := range rv.MapKeys() {
+			v, err := normalize(rv.MapIndex(k).Interface())
+			if err != nil {
+				return nil, err
+			}
+			ret[k.String()] = v
+		}
+		return ret, nil
+
+	case reflect.Struct:
+		t := rv.Type()
+
+		if t == reflect.TypeOf(time.Time{}) {
+			return value, nil
+		}
+
+		ret := map[string]any{}
+
+		for i := 0; i < t.NumField(); i++ {
+			ft := t.Field(i)
+			name, omit := parseTags(ft)
+			if omit {
+				continue
+			}
+
+			v, err := normalize(rv.Field(i).Interface())
+			if err != nil {
+				return nil, err
+			}
+			ret[name] = v
+		}
+
+		return ret, nil
+
+	// Invalid, Complex64, Complex128, Chan, Func, Uintptr, UnsafePointer
+	default:
+		return nil, fmt.Errorf("automerge: unsupported type %v", rv.Kind())
+	}
+}
+
+func parseTags(ft reflect.StructField) (name string, omit bool) {
+	tag := ft.Tag.Get("automerge")
+	if tag == "-" || !ft.IsExported() {
+		return "", true
+	}
+	name, _, _ = strings.Cut(tag, ",")
+	if name == "" {
+		name = ft.Name
+	}
+	return name, false
 }
 
 // As converts v to type T.
@@ -80,39 +145,227 @@ func As[T any](v *Value, errs ...error) (ret T, err error) {
 		return
 	}
 
-	switch (any)(ret).(type) {
-	case *Map:
-		if v.Kind() == KindMap {
-			return v.val.(T), nil
-		}
-	case *List:
-		if v.Kind() == KindList {
-			return v.val.(T), nil
-		}
-	case *Counter:
-		if v.Kind() == KindCounter {
-			return v.val.(T), nil
-		}
-	case *Text:
-		if v.Kind() == KindText {
-			return v.val.(T), nil
-		}
+	err = unmarshal(reflect.ValueOf(&ret).Elem(), v)
+	return
+}
 
-	default:
-		var val any
-		val = v.Interface()
-		if r, ok := val.(T); ok {
-			return r, nil
+func unmarshalNumber[T interface{ int64 | float64 | uint64 }](overflows func(T) bool, set func(T), v *Value) bool {
+	switch v.Kind() {
+	case KindFloat64:
+		f := v.Float64()
+		if float64(T(f)) == f && !overflows(T(f)) {
+			set(T(f))
+			return true
 		}
-		if bytes, err := json.Marshal(val); err == nil {
-			if err == nil {
-				if err := json.Unmarshal(bytes, &ret); err == nil {
-					return ret, nil
-				}
-			}
+	case KindInt64:
+		i := v.Int64()
+		if (T(i) > 0) == (i > 0) && !overflows(T(i)) {
+			set(T(i))
+			return true
+		}
+	case KindUint64:
+		u := v.Uint64()
+		if T(u) > 0 && !overflows(T(u)) {
+			set(T(u))
+			return true
+		}
+	case KindCounter:
+		i := v.Counter().val
+		if (T(i) > 0) == (i > 0) && !overflows(T(i)) {
+			set(T(i))
+			return true
 		}
 	}
+	return false
+}
 
-	err = fmt.Errorf("automerge: could not convert %#v from %T to %T", v.val, v.val, ret)
-	return
+func unmarshal(rv reflect.Value, v *Value) error {
+	switch rv.Kind() {
+	case reflect.Bool:
+		if v.Kind() == KindBool {
+			rv.SetBool(v.Bool())
+			return nil
+		}
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if unmarshalNumber(rv.OverflowInt, rv.SetInt, v) {
+			return nil
+		}
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		if unmarshalNumber(rv.OverflowUint, rv.SetUint, v) {
+			return nil
+		}
+
+	case reflect.Float32, reflect.Float64:
+		if unmarshalNumber(rv.OverflowFloat, rv.SetFloat, v) {
+			return nil
+		}
+
+	case reflect.String:
+		switch v.Kind() {
+		case KindStr:
+			rv.SetString(v.Str())
+			return nil
+		case KindText:
+			s, err := v.Text().Get()
+			if err != nil {
+				return err
+			}
+			rv.SetString(s)
+			return nil
+		}
+
+	case reflect.Interface:
+		val := reflect.ValueOf(v.Interface())
+		if !val.IsValid() {
+			// reflect.ValueOf(nil) returns the zero Value which cannot be used.
+			// reflect.Zero() returns the Value representing the nil value of the current type,
+			// which can be...
+			val = reflect.Zero(rv.Type())
+		}
+		rv.Set(val)
+		return nil
+
+	case reflect.Ptr:
+		if rv.Type() == reflect.TypeOf(&Map{}) && v.Kind() == KindMap {
+			rv.Set(reflect.ValueOf(v.val))
+			return nil
+		}
+		if rv.Type() == reflect.TypeOf(&List{}) && v.Kind() == KindList {
+			rv.Set(reflect.ValueOf(v.val))
+			return nil
+		}
+		if rv.Type() == reflect.TypeOf(&Counter{}) && v.Kind() == KindCounter {
+			rv.Set(reflect.ValueOf(v.val))
+			return nil
+		}
+		if rv.Type() == reflect.TypeOf(&Text{}) && v.Kind() == KindText {
+			rv.Set(reflect.ValueOf(v.val))
+			return nil
+		}
+
+		r := reflect.New(rv.Type().Elem())
+		if err := unmarshal(r.Elem(), v); err != nil {
+			return err
+		}
+		rv.Set(r)
+		return nil
+
+	case reflect.Slice:
+		if v.Kind() == KindBytes && rv.Type().AssignableTo(reflect.TypeOf([]byte{})) {
+			rv.Set(reflect.ValueOf(v.Bytes()))
+			return nil
+		}
+		if v.Kind() != KindList {
+			break
+		}
+
+		vals, err := v.List().Values()
+		if err != nil {
+			return err
+		}
+
+		nl := reflect.New(rv.Type()).Elem()
+		for _, lv := range vals {
+			v := reflect.New(rv.Type().Elem())
+			if err := unmarshal(v.Elem(), lv); err != nil {
+				return err
+			}
+			nl = reflect.Append(nl, v.Elem())
+		}
+		rv.Set(nl)
+		return nil
+
+	case reflect.Array:
+		if v.Kind() != KindList {
+			break
+		}
+
+		vals, err := v.List().Values()
+		if err != nil {
+			return err
+		}
+		max := len(vals)
+		if rv.Len() < max {
+			max = rv.Len()
+		}
+
+		for i := 0; i < max; i++ {
+			if err := unmarshal(rv.Index(i), vals[i]); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	case reflect.Map:
+		if v.Kind() != KindMap {
+			return fmt.Errorf("automerge: cannot unmarshal %s into %s", v.Kind(), rv.Type().String())
+		}
+
+		if rv.Type().Key().Kind() != reflect.String {
+			return fmt.Errorf("automerge: unsupported map, must have string keys")
+		}
+
+		vals, err := v.Map().Values()
+		if err != nil {
+			return err
+		}
+
+		nm := reflect.MakeMapWithSize(rv.Type(), len(vals))
+
+		for mk, mv := range vals {
+			rk := reflect.New(rv.Type().Key())
+			rk.Elem().SetString(mk)
+
+			rv := reflect.New(rv.Type().Elem())
+			if err := unmarshal(rv.Elem(), mv); err != nil {
+				return err
+			}
+
+			nm.SetMapIndex(rk.Elem(), rv.Elem())
+		}
+
+		rv.Set(nm)
+		return nil
+
+	case reflect.Struct:
+		if v.Kind() == KindTime && rv.Type().AssignableTo(reflect.TypeOf(time.Now())) {
+			rv.Set(reflect.ValueOf(v.Time()))
+			return nil
+		}
+
+		if v.Kind() != KindMap {
+			return fmt.Errorf("automerge: cannot unmarshal %s into %s", v.Kind(), rv.Type().String())
+		}
+
+		vals, err := v.Map().Values()
+		if err != nil {
+			return err
+		}
+
+		s := reflect.New(rv.Type()).Elem()
+
+		for i := 0; i < rv.Type().NumField(); i++ {
+			ft := rv.Type().Field(i)
+			name, omit := parseTags(ft)
+			if omit {
+				continue
+			}
+
+			if mv, ok := vals[name]; ok {
+				if err := unmarshal(s.Field(i), mv); err != nil {
+					return err
+				}
+			}
+
+			rv.Set(s)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("automerge: unsupported type %v", rv.Kind())
+	}
+
+	return fmt.Errorf("automerge: cannot unmarshal %s into %s", v.Kind(), rv.Type().String())
 }

--- a/normalize.go
+++ b/normalize.go
@@ -100,7 +100,7 @@ func As[T any](v *Value, errs ...error) (ret T, err error) {
 
 	default:
 		var val any
-		val = v.goValue()
+		val = v.Interface()
 		if r, ok := val.(T); ok {
 			return r, nil
 		}

--- a/normalize.go
+++ b/normalize.go
@@ -7,11 +7,6 @@ import (
 	"time"
 )
 
-var (
-	boolType   = reflect.TypeOf(true)
-	stringType = reflect.TypeOf("")
-)
-
 // normalize converts the value into a type expected by Put()
 // bool/string/[]byte/int64/uint64/float64/time.Time/[]any/map[string]any/*Text/*Counter
 func normalize(value any) (any, error) {

--- a/normalize_test.go
+++ b/normalize_test.go
@@ -1,0 +1,95 @@
+package automerge_test
+
+import (
+	"testing"
+
+	"github.com/automerge/automerge-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAs(t *testing.T) {
+
+	doc := automerge.New()
+	require.NoError(t, doc.RootMap().Set("float64", float64(1.5)))
+	l := automerge.NewList()
+	require.NoError(t, doc.RootMap().Set("list", l))
+	require.NoError(t, l.Append(1))
+
+	ret, err := automerge.As[any](doc.RootMap().Get("list"))
+	require.NoError(t, err)
+	require.Equal(t, ret, []any{float64(1)})
+
+	rets, err := automerge.As[[]any](doc.RootMap().Get("list"))
+	require.NoError(t, err)
+	require.Equal(t, rets, []any{float64(1)})
+
+	require.NoError(t, doc.Path("list").List().Append(2))
+	arr, err := automerge.As[[2]uint16](doc.RootMap().Get("list"))
+	require.NoError(t, err)
+	require.Equal(t, arr, [2]uint16{1, 2})
+
+	m := automerge.NewMap()
+	require.NoError(t, doc.RootMap().Set("map", m))
+	require.NoError(t, m.Set("x", 5))
+
+	d, err := automerge.As[float64](doc.RootMap().Get("float64"))
+	require.NoError(t, err)
+	require.Equal(t, d, 1.5)
+
+	ret2, err := automerge.As[[]int](doc.RootMap().Get("list"))
+	require.NoError(t, err)
+	require.Equal(t, ret2, []int{1, 2})
+
+	retm, err := automerge.As[map[string]int](doc.RootMap().Get("map"))
+	require.NoError(t, err)
+	require.Equal(t, retm, map[string]int{"x": 5})
+
+	require.NoError(t, m.Set("one", "six"))
+	require.NoError(t, m.Set("two", uint(5)))
+
+	type Y string
+	type X struct {
+		X int `automerge:"x"`
+		Y Y   `automerge:"one"`
+	}
+
+	r, err := automerge.As[*X](doc.RootMap().Get("map"))
+	require.NoError(t, err)
+	require.Equal(t, r, &X{5, Y("six")})
+
+	require.Error(t, doc.RootMap().Set("map", map[int]int{1: 1}))
+}
+
+func TestTags(t *testing.T) {
+	doc := automerge.New()
+	require.Error(t, doc.RootMap().Set("map", map[int]int{1: 1}))
+
+	type X struct {
+		X int     `automerge:"x"`
+		Y uint    `automerge:"-"`
+		Z float32 `automerge:"z"`
+	}
+
+	require.NoError(t, doc.RootMap().Set("x", &X{1, 2, 0}))
+
+	m, err := automerge.As[map[string]any](doc.RootMap().Get("x"))
+	require.NoError(t, err)
+	require.Equal(t, m, map[string]any{"x": 1.0, "z": 0.0})
+
+	type S struct {
+		H string `automerge:"h"`
+		i int64  `automerge:"i"`
+	}
+
+	require.NoError(t, doc.RootMap().Set("s", &S{H: "hello", i: 5}))
+	require.NoError(t, doc.Path("s", "i").Set(7))
+
+	s, err := automerge.As[S](doc.Path("s").Get())
+	require.NoError(t, err)
+	require.Equal(t, s.H, "hello")
+	require.Equal(t, s.i, int64(0))
+
+	v, err := doc.Path("i").Get()
+	require.NoError(t, err)
+	require.True(t, v.IsVoid())
+}

--- a/path.go
+++ b/path.go
@@ -8,16 +8,23 @@ type Path struct {
 	path []any
 }
 
+type deleteIndicator int
+
+var toDelete = deleteIndicator(0)
+
 // Path extends the cursor with more path segments.
 // It panics if any path segment is not a string or an int.
 // It does not check that the path segment is traversable until you call
 // a method that accesses the document.
 func (p *Path) Path(path ...any) *Path {
-	for _, v := range path {
-		if _, ok := v.(string); !ok {
-			if _, ok := v.(int); !ok {
-				panic(fmt.Errorf("automerge: invalid path segment, expected string or int, got: %T(%#v)", v, v))
-			}
+	for i, v := range path {
+		rv := reflect.ValueOf(v)
+		if rv.CanInt() {
+			path[i] = int(rv.Int())
+		} else if rv.CanConvert(reflect.TypeOf("")) {
+			path[i] = rv.String()
+		} else {
+			panic(fmt.Errorf("automerge: invalid path segment, expected string or int, got: %T(%#v)", v, v))
 		}
 	}
 	return &Path{d: p.d, path: append(p.path, path...)}

--- a/sync_state.go
+++ b/sync_state.go
@@ -11,7 +11,7 @@ import (
 // a doc and a peer; and lets you optimize bandwidth used to ensure
 // two docs are always in sync.
 type SyncState struct {
-	doc  *Doc
+	Doc  *Doc
 	item *item
 
 	cSyncState *C.AMsyncState
@@ -20,7 +20,7 @@ type SyncState struct {
 // NewSyncState returns a new sync state to sync with a peer
 func NewSyncState(d *Doc) *SyncState {
 	ss := must(wrap(C.AMsyncStateInit()).item()).syncState()
-	ss.doc = d
+	ss.Doc = d
 	return ss
 }
 
@@ -34,7 +34,7 @@ func LoadSyncState(d *Doc, raw []byte) (*SyncState, error) {
 		return nil, err
 	}
 	ss := item.syncState()
-	ss.doc = d
+	ss.Doc = d
 	return ss, nil
 }
 
@@ -48,7 +48,7 @@ func (ss *SyncState) ReceiveMessage(msg []byte) error {
 
 	defer runtime.KeepAlive(ss)
 	defer runtime.KeepAlive(sm)
-	cDoc, unlock := ss.doc.lock()
+	cDoc, unlock := ss.Doc.lock()
 	defer unlock()
 
 	return wrap(C.AMreceiveSyncMessage(cDoc, ss.cSyncState, sm.cSyncMessage)).void()
@@ -59,7 +59,7 @@ func (ss *SyncState) ReceiveMessage(msg []byte) error {
 // no more messages to send (until you either modify the underlying document)
 func (ss *SyncState) GenerateMessage() (bytes []byte, valid bool) {
 	defer runtime.KeepAlive(ss)
-	cDoc, unlock := ss.doc.lock()
+	cDoc, unlock := ss.Doc.lock()
 	defer unlock()
 
 	sm := must(wrap(C.AMgenerateSyncMessage(cDoc, ss.cSyncState)).item()).syncMessage()

--- a/sync_state.go
+++ b/sync_state.go
@@ -40,10 +40,10 @@ func LoadSyncState(d *Doc, raw []byte) (*SyncState, error) {
 
 // ReceiveMessage should be called with every message created by GenerateMessage
 // on the peer side.
-func (ss *SyncState) ReceiveMessage(msg []byte) error {
+func (ss *SyncState) ReceiveMessage(msg []byte) (*SyncMessage, error) {
 	sm, err := loadSyncMessage(msg)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	defer runtime.KeepAlive(ss)
@@ -51,45 +51,42 @@ func (ss *SyncState) ReceiveMessage(msg []byte) error {
 	cDoc, unlock := ss.Doc.lock()
 	defer unlock()
 
-	return wrap(C.AMreceiveSyncMessage(cDoc, ss.cSyncState, sm.cSyncMessage)).void()
+	return sm, wrap(C.AMreceiveSyncMessage(cDoc, ss.cSyncState, sm.cSyncMessage)).void()
 }
 
 // GenerateMessage generates the next message to send to the client.
 // If `valid` is false the clients are currently in sync and there are
 // no more messages to send (until you either modify the underlying document)
-func (ss *SyncState) GenerateMessage() (bytes []byte, valid bool) {
+func (ss *SyncState) GenerateMessage() (sm *SyncMessage, valid bool) {
 	defer runtime.KeepAlive(ss)
 	cDoc, unlock := ss.Doc.lock()
 	defer unlock()
 
-	sm := must(wrap(C.AMgenerateSyncMessage(cDoc, ss.cSyncState)).item()).syncMessage()
+	sm = must(wrap(C.AMgenerateSyncMessage(cDoc, ss.cSyncState)).item()).syncMessage()
 
 	if sm == nil {
 		return nil, false
 	}
 
-	return sm.save(), true
+	return sm, true
 }
 
 // Save serializes the sync state so that you can resume it later.
 // This is an optimization to reduce the number of round-trips required
 // to get two peers in sync at a later date.
-func (ss *SyncState) Save() ([]byte, error) {
+func (ss *SyncState) Save() []byte {
 	defer runtime.KeepAlive(ss)
 
-	item, err := wrap(C.AMsyncStateEncode(ss.cSyncState)).item()
-	if err != nil {
-		return nil, err
-	}
-	return item.bytes(), nil
+	return must(wrap(C.AMsyncStateEncode(ss.cSyncState)).item()).bytes()
 }
 
-type syncMessage struct {
+// SyncMessage is sent between peers to keep copies of a document in sync.
+type SyncMessage struct {
 	item         *item
 	cSyncMessage *C.AMsyncMessage
 }
 
-func loadSyncMessage(msg []byte) (*syncMessage, error) {
+func loadSyncMessage(msg []byte) (*SyncMessage, error) {
 	cBytes, free := toByteSpan(msg)
 	defer free()
 
@@ -100,7 +97,26 @@ func loadSyncMessage(msg []byte) (*syncMessage, error) {
 	return item.syncMessage(), nil
 }
 
-func (sm *syncMessage) save() []byte {
+// Changes returns any changes included in this SyncMessage
+func (sm *SyncMessage) Changes() []*Change {
+	defer runtime.KeepAlive(sm)
+
+	items := must(wrap(C.AMsyncMessageChanges(sm.cSyncMessage)).items())
+
+	return mapItems(items, func(i *item) *Change { return i.change() })
+}
+
+// Heads gives the heads of the peer that generated the SyncMessage
+func (sm *SyncMessage) Heads() []ChangeHash {
+	defer runtime.KeepAlive(sm)
+
+	items := must(wrap(C.AMsyncMessageHeads(sm.cSyncMessage)).items())
+
+	return mapItems(items, func(i *item) ChangeHash { return i.changeHash() })
+}
+
+// Bytes returns a representation for sending over the network.
+func (sm *SyncMessage) Bytes() []byte {
 	if sm == nil {
 		return nil
 	}

--- a/value.go
+++ b/value.go
@@ -171,18 +171,22 @@ func (v *Value) assertKind(k Kind) {
 	}
 }
 
-func (v *Value) goValue() any {
+// Interface returns the value as a go interface.
+// It recursively converts automerge.Map to map[string]any,
+// automerge.List to []any, automerge.Text to string, and
+// automerge.Counter to int64.
+func (v *Value) Interface() any {
 	switch v.kind {
 	case KindMap:
 		values, err := v.Map().Values()
 		// this should not be able to happen because .load() is only
-		// called from Value.goValue() which checks that this is a map.
+		// called from Value.Interface() which checks that this is a map.
 		if err != nil {
 			panic(err)
 		}
 		out := map[string]any{}
 		for k, v := range values {
-			out[k] = v.goValue()
+			out[k] = v.Interface()
 		}
 		return out
 	case KindList:
@@ -193,7 +197,7 @@ func (v *Value) goValue() any {
 		}
 		out := []any{}
 		for _, v := range values {
-			out = append(out, v.goValue())
+			out = append(out, v.Interface())
 		}
 		return out
 	case KindText:


### PR DESCRIPTION
A few quality of life improvements from actually trying to use automerge-go in anger.

The biggest change is to avoid using the JSON library for serialization/deserialization.

- Rename .Del -> .Delete for consistency
- Work with type aliases
- Add Value#Interface()
- Add Path#Delete()
- Make Doc public on sync state
- Expose SyncMessage
- Rewrite serialization code to avoid JSON
