### PR TITLE
Export the LoadSyncMessage function

### DIFF
--- a/sync_state.go
+++ b/sync_state.go
@@ -41,7 +41,7 @@ func LoadSyncState(d *Doc, raw []byte) (*SyncState, error) {
 // ReceiveMessage should be called with every message created by GenerateMessage
 // on the peer side.
 func (ss *SyncState) ReceiveMessage(msg []byte) (*SyncMessage, error) {
-	sm, err := loadSyncMessage(msg)
+	sm, err := LoadSyncMessage(msg)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,8 @@ type SyncMessage struct {
 	cSyncMessage *C.AMsyncMessage
 }
 
-func loadSyncMessage(msg []byte) (*SyncMessage, error) {
+// LoadSyncMessage decodes a sync message from a byte slice for inspection.
+func LoadSyncMessage(msg []byte) (*SyncMessage, error) {
 	cBytes, free := toByteSpan(msg)
 	defer free()
 


### PR DESCRIPTION
**TL;DR**: this change makes an existing loadSyncMessage function public by capitalising it.

I'd like to have access to the LoadSyncMessage function so that I can inspect a received message before merging it into the document. This would allow me to do things like:

1. Accept only empty sync messages and reject those with changes
2. Inspecting the actor id and message of a change within the sync message and rejecting or verifying based on the information

Right now I can only achieve this by accepting the change, checking it, and then forking the document based on the previous heads in order to "rollback" which is obviously more expensive than I'd like.

Thanks!